### PR TITLE
Add Opencode model selection

### DIFF
--- a/backend/src/execution_monitor.rs
+++ b/backend/src/execution_monitor.rs
@@ -77,12 +77,20 @@ async fn handle_setup_delegation(app_state: &AppState, delegation_context: Deleg
             .await
         }
         "coding_agent" => {
+            let model_param = params
+                .additional
+                .as_ref()
+                .and_then(|a| a.get("model"))
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+
             ProcessService::start_coding_agent(
                 &app_state.db_pool,
                 app_state,
                 attempt_id,
                 task_id,
                 project_id,
+                model_param,
             )
             .await
         }
@@ -781,6 +789,7 @@ async fn handle_setup_completion(
                         task_attempt_id,
                         task.id,
                         task.project_id,
+                        None,
                     )
                     .await
                     {

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -31,6 +31,7 @@ use execution_monitor::execution_monitor;
 use models::{ApiResponse, Config};
 use routes::{
     auth, config, filesystem, health, projects, stream, task_attempts, task_templates, tasks,
+    opencode,
 };
 use services::PrMonitorService;
 
@@ -203,6 +204,7 @@ fn main() -> anyhow::Result<()> {
                         .merge(stream::stream_router())
                         .merge(task_templates::templates_router())
                         .merge(filesystem::filesystem_router())
+                        .merge(opencode::opencode_router())
                         .merge(config::config_router())
                         .merge(auth::auth_router())
                         .route("/sounds/:filename", get(serve_sound_file))

--- a/backend/src/models/task_attempt.rs
+++ b/backend/src/models/task_attempt.rs
@@ -109,6 +109,7 @@ pub struct TaskAttempt {
 pub struct CreateTaskAttempt {
     pub executor: Option<String>, // Optional executor name (defaults to "echo")
     pub base_branch: Option<String>, // Optional base branch to checkout (defaults to current HEAD)
+    pub model: Option<String>, // Optional model for executors like opencode
 }
 
 #[derive(Debug, Deserialize, TS)]
@@ -612,8 +613,17 @@ impl TaskAttempt {
         attempt_id: Uuid,
         task_id: Uuid,
         project_id: Uuid,
+        model: Option<String>,
     ) -> Result<(), TaskAttemptError> {
-        ProcessService::start_execution(pool, app_state, attempt_id, task_id, project_id).await
+        ProcessService::start_execution(
+            pool,
+            app_state,
+            attempt_id,
+            task_id,
+            project_id,
+            model,
+        )
+        .await
     }
 
     /// Start a dev server for this task attempt

--- a/backend/src/routes/mod.rs
+++ b/backend/src/routes/mod.rs
@@ -7,3 +7,4 @@ pub mod stream;
 pub mod task_attempts;
 pub mod task_templates;
 pub mod tasks;
+pub mod opencode;

--- a/backend/src/routes/opencode.rs
+++ b/backend/src/routes/opencode.rs
@@ -1,0 +1,47 @@
+use axum::{routing::get, Json as ResponseJson, Router};
+use tokio::process::Command;
+
+use crate::{app_state::AppState, models::ApiResponse, utils::shell::get_shell_command};
+
+pub fn opencode_router() -> Router<AppState> {
+    Router::new().route("/opencode/models", get(get_models))
+}
+
+async fn get_models() -> ResponseJson<ApiResponse<Vec<String>>> {
+    let (shell_cmd, shell_arg) = get_shell_command();
+    let output = Command::new(shell_cmd)
+        .arg(shell_arg)
+        .arg("opencode models")
+        .output()
+        .await;
+
+    match output {
+        Ok(out) if out.status.success() => {
+            let stdout = String::from_utf8_lossy(&out.stdout);
+            let models = stdout
+                .lines()
+                .map(|l| l.trim())
+                .filter(|l| !l.is_empty())
+                .map(String::from)
+                .collect();
+            ResponseJson(ApiResponse {
+                success: true,
+                data: Some(models),
+                message: Some("Opencode models retrieved successfully".to_string()),
+            })
+        }
+        Ok(out) => ResponseJson(ApiResponse {
+            success: false,
+            data: None,
+            message: Some(format!(
+                "Failed to run opencode models: exit code {}",
+                out.status
+            )),
+        }),
+        Err(e) => ResponseJson(ApiResponse {
+            success: false,
+            data: None,
+            message: Some(format!("Failed to run opencode models: {}", e)),
+        }),
+    }
+}

--- a/backend/src/routes/task_attempts.rs
+++ b/backend/src/routes/task_attempts.rs
@@ -285,6 +285,7 @@ pub async fn create_task_attempt(
                     attempt_id,
                     task_id,
                     project_id,
+                    payload.model.clone(),
                 )
                 .await
                 {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -22,7 +22,7 @@ export type SoundConstants = { sound_files: Array<SoundFile>, sound_labels: Arra
 
 export type ConfigConstants = { editor: EditorConstants, sound: SoundConstants, };
 
-export type ExecutorConfig = { "type": "echo" } | { "type": "claude" } | { "type": "claude-plan" } | { "type": "amp" } | { "type": "gemini" } | { "type": "setup-script", script: string, } | { "type": "claude-code-router" } | { "type": "charm-opencode" } | { "type": "sst-opencode" };
+export type ExecutorConfig = { "type": "echo" } | { "type": "claude" } | { "type": "claude-plan" } | { "type": "amp" } | { "type": "gemini" } | { "type": "setup-script", script: string, } | { "type": "claude-code-router" } | { "type": "charm-opencode" } | { "type": "sst-opencode", model: string | null, };
 
 export type ExecutorConstants = { executor_types: Array<ExecutorConfig>, executor_labels: Array<string>, };
 
@@ -64,7 +64,7 @@ export type TaskAttemptStatus = "setuprunning" | "setupcomplete" | "setupfailed"
 
 export type TaskAttempt = { id: string, task_id: string, worktree_path: string, branch: string, base_branch: string, merge_commit: string | null, executor: string | null, pr_url: string | null, pr_number: bigint | null, pr_status: string | null, pr_merged_at: string | null, worktree_deleted: boolean, setup_completed_at: string | null, created_at: string, updated_at: string, };
 
-export type CreateTaskAttempt = { executor: string | null, base_branch: string | null, };
+export type CreateTaskAttempt = { executor: string | null, base_branch: string | null, model: string | null, };
 
 export type UpdateTaskAttempt = Record<string, never>;
 


### PR DESCRIPTION
## Summary
- support passing optional model to SST Opencode executor
- expose new /opencode/models route

## Testing
- `npm run generate-types`
- `cargo check --manifest-path backend/Cargo.toml`
- `npm run build` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_687ae4ba1a6883299e98f4e31c044a48